### PR TITLE
Amend role to enable better user firewall settings

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -106,9 +106,10 @@ harden_linux_sshd_settings:
 
 # By default we only allow SSH inbound traffic.
 harden_linux_ufw_rules:
-  - rule: "allow"
-    to_port: "22"
-    protocol: "tcp"
+    - service: "ssh"
+      rule: "allow"
+      to_port: "22"
+      protocol: "tcp"
 
 # Defaults for UFW (/etc/default/ufw). Same rules as for
 # harden_linux_sshd_settings applies.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -158,6 +158,13 @@
   tags:
     - ufw
 
+- name: Combine harden_linux_ufw_rules and harden_linux_ufw_rules_user (if defined)
+  set_fact:
+    harden_linux_ufw_rules: "{{ harden_linux_ufw_rules | union(harden_linux_ufw_rules_user|default({})) }}"
+  when: harden_linux_ufw_rules_user is defined
+  tags:
+    - ufw
+
 - name: UFW - Apply firewall rules
   ufw:
     rule: "{{ item.rule }}"
@@ -170,6 +177,7 @@
     protocol: "{{ item.protocol | default('any') }}"
     log: "{{ item.log | default(False) }}"
   with_items: "{{ harden_linux_ufw_rules }}"
+
   tags:
     - ufw
     - ufwrules


### PR DESCRIPTION
Change tasks/main.yml to merge harden_linux_ufw_rules with user-defined
rules in harden_linux_ufw_rules_user, if the latter is specified.

Change defaults/main.yml to use the new, extended UFW service
specification for the default ssh service:

harden_linux_ufw_rules:
       - service: "ssh"
         rule: "allow"
         to_port: "22"
         protocol: "tcp"