### PR TITLE
Remove Ubuntu 16.04 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+**v5.0.0**
+
+- Remove Ubunut 16.04 support
+
 **v4.1.0**
 
 - Added basic Molecule tests

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ansible-role-harden-linux
 =========================
 
-This Ansible role was mainly created for [Kubernetes the not so hard way with Ansible - Harden the instances](https://www.tauceti.blog/post/kubernetes-the-not-so-hard-way-with-ansible-harden-the-instances//). But it can be used also standalone of course to harden Linux (targeting Ubuntu 16.04/18.04/20.04 mainly at the moment). It has the following features:
+This Ansible role was mainly created for [Kubernetes the not so hard way with Ansible - Harden the instances](https://www.tauceti.blog/post/kubernetes-the-not-so-hard-way-with-ansible-harden-the-instances//). But it can be used also standalone of course to harden Linux (targeting Ubuntu 18.04/20.04 mainly at the moment). It has the following features:
 
 - Change root password
 - Add a regular/deploy user used for administration (e.g. for Ansible or login via SSH)

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,8 +53,7 @@ harden_linux_ntp_settings:
 # This would be cool but doesn't work with UFW very well so leave it out:
 # "kernel.modules_disabled": 1                    # Disable CAP_SYS_MODULE which allows for loading and unloading of kernel modules.
                                                   # If you set kernel.modules_disabled=1 you're not able to load new netfilter/iptable
-                                                  # modules anymore (at least on Ubuntu 16.04)! So "ufw" would fail to start if
-                                                  # it is loaded afterwards.
+                                                  # modules anymore! So "ufw" would fail to start if it is loaded afterwards.
 # Add this to "sysctl_settings_user" to turn off ipv6 autoconfiguration:
 # "net.ipv6.conf.default.autoconf": 0
 # "net.ipv6.conf.all.autoconf": 0

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -1,12 +1,11 @@
 galaxy_info:
   author: Robert Wimmer
-  description: Ansible role for hardening Linux (targeting Ubuntu 16.04/18.04/20.04 mainly)
+  description: Ansible role for hardening Linux (targeting Ubuntu 18.04/20.04 mainly)
   license: GPLv3
   min_ansible_version: 2.5
   platforms:
   - name: Ubuntu
     versions:
-    - xenial
     - bionic
     - focal
   galaxy_tags:


### PR DESCRIPTION
Ubuntu 16.04 is officially unsupported since May 2021.