### PR TITLE
v8.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v8.0.0
+
+BREAKING/FEATURE
+
+- introduce `harden_linux_deploy_group` and `harden_linux_deploy_group_gid` variables. Both are optional. But at least `harden_linux_deploy_group` must be specified if `harden_linux_deploy_user` is also set. If `harden_linux_deploy_group` is set to `root` nothing will be changed.
+- if `harden_linux_deploy_user` is set to `root` nothing will be changed.
+- `harden_linux_deploy_user` is now optional. If not set, no user will be setup. Also all variables that start with `harden_linux_deploy_user_` are only used if `harden_linux_deploy_user` is specified. Additionally `harden_linux_deploy_user_home` variable was added. `harden_linux_deploy_user_shell`, `harden_linux_deploy_user_home`, `harden_linux_deploy_user_uid` and `harden_linux_deploy_user_password` are now optional. $HOME directory of `harden_linux_deploy_user` is only created if `harden_linux_deploy_user_home` is set.
+
+MOLECULE
+
+- update test scenario to reflect deploy user/group changes
+
 ## v7.1.0
 
 FEATURE

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,44 @@
 ---
-# Some default settings for deploy user
-harden_linux_deploy_user_uid: 9999
-harden_linux_deploy_user_shell: "/bin/bash"
+# If you want to set or change the password of the "root" user set this variable.
+#
+# The encrypted password can be created with the following command:
+# ansible localhost -m debug -a "msg={{ 'mypassword' | password_hash('sha512', 'mysecretsalt') }}"
+#
+# harden_linux_root_password: "a_password"
+
+# Group name of deploy user. This is mandatory if "harden_linux_deploy_user"
+# is also set.
+# harden_linux_deploy_group: "a_group"
+
+# The GID of the group name specified in "harden_linux_deploy_group". If not
+# specified the next available GID from "/etc/login.defs" will be taken
+# (see "GID_MIN/GID_MAX" setting in that file).
+# harden_linux_deploy_group_gid: 9999
+
+# Name of deploy user. When not set no user will be created.
+# harden_linux_deploy_user: "a_username"
+
+# Encrypted password for deploy user. Only relevant if "harden_linux_deploy_user"
+# is set. See "harden_linux_root_password" how to create an encrypted password.
+# harden_linux_deploy_user_password: "a_password"
+
+# HOME directory for deploy user. Only relevant when "harden_linux_deploy_user"
+# is set.
+# harden_linux_deploy_user_home: "/home/a_user"
+
+# List of public keys for deploy user. Only relevant when "harden_linux_deploy_user"
+# is set. The public keys will be added to the "authorized_keys" file of the deploy
+# user.
+# harden_linux_deploy_user_public_keys:
+#  - /home/a_username/.ssh/id_rsa.pub
+
+# UID for deploy user. Only relevant when "harden_linux_deploy_user" is set.
+# If not specified the next available GID from "/etc/login.defs" will be taken
+# (see "UID_MIN/UID_MAX" setting in that file).
+# harden_linux_deploy_user_uid: "9999"
+
+# Shell for deploy user. Only relevant when "harden_linux_deploy_user" is set.
+# harden_linux_deploy_user_shell: "/bin/bash"
 
 # List of files that should be absent on the target host
 harden_linux_files_to_delete:
@@ -85,7 +122,7 @@ harden_linux_files_to_delete:
 # on your own by adding a group or host variable called "sysctl_settings_user".
 # "sysctl_settings" and "sysctl_settings_user" will get merged by a
 # task. You can also override a setting defined in "sysctl_settings"
-# by specifing a key with the same name and a different value in
+# by specifying a key with the same name and a different value in
 # "sysctl_settings_user".
 #
 # For more information about this settings have a look at:
@@ -143,14 +180,14 @@ harden_linux_sysctl_settings:
 # The "key" here is a regex of a setting you want to replace and the value is
 # the setting name + the setting value. E.g. we want to replace the line
 # "Port 22" with "Port 22222". The regex (the key) would be "^Port " which
-# means "search for a line in "/etc/ssh/sshd_config" that begins with 'Port'
+# means "search for a line in "/etc/ssh/sshd_config" that begins with 'Port '
 # and replace the whole line with 'Port 22222'". This enables you to replace
 # every setting in "sshd_config".
 harden_linux_sshd_settings:
   "^PasswordAuthentication": "PasswordAuthentication no"  # Disable password authentication
   "^PermitRootLogin": "PermitRootLogin no"                # Disable SSH root login
   "^PermitTunnel": "PermitTunnel no"                      # Disable tun(4) device forwarding
-  "^Port ": "Port 22"                                     # Set SSHd port
+  "^Port ": "Port 22"                                     # Set sshd port
 
 # When this variable is set, settings for "systemd-resolved" will be changed.
 # A systemd drop-in configuration will be created in "/etc/systemd/resolved.conf.d/99-override.conf"
@@ -194,7 +231,7 @@ harden_linux_ufw_defaults:
 # Disable/enable UFW logging
 harden_linux_ufw_logging: 'off'
 
-# sshgard whitelist: sshguard blocks IPs for some time if
+# sshguard whitelist: sshguard blocks IPs for some time if
 # to many SSH login attempts fail. Specify IP (ranges) that
 # should not be blocked.
 harden_linux_sshguard_whitelist:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -76,11 +76,6 @@ provisioner:
   inventory:
     group_vars:
       all:
-        harden_linux_deploy_user: deployer
-        harden_linux_deploy_user_password: "{{ lookup('file', 'myuserpassword_hash') }}" # mypassword
-        harden_linux_deploy_user_home: /home/deployer
-        harden_linux_deploy_user_public_keys:
-          - "mykey.pub"
         harden_linux_sshd_settings:
           "^PasswordAuthentication": "PasswordAuthentication yes"
           "^X11Forwarding": "X11Forwarding no"
@@ -111,12 +106,24 @@ provisioner:
           - "10.0.0.0/8"
     host_vars:
       test-harden-linux-ubuntu2004-timesyncd:
+        harden_linux_deploy_group: "deployer"
+        harden_linux_deploy_user: "deployer"
+        harden_linux_deploy_user_password: "{{ lookup('file', 'myuserpassword_hash') }}" # mypassword
+        harden_linux_deploy_user_home: "/home/deployer"
+        harden_linux_deploy_user_shell: "/bin/bash"
+        harden_linux_deploy_user_public_keys:
+          - "mykey.pub"
         harden_linux_ntp: "systemd-timesyncd"
         harden_linux_ntp_settings:
           "^#NTP=": "NTP=ntp.ubuntu.com"
         harden_linux_optional_packages:
           - mlocate
       test-harden-linux-ubuntu2004-ntp:
+        harden_linux_deploy_group: "deployer"
+        harden_linux_deploy_user: "deployer"
+        harden_linux_deploy_user_home: "/home/deployer"
+        harden_linux_deploy_user_public_keys:
+          - "mykey.pub"
         harden_linux_root_password: "{{ lookup('file', 'myuserpassword_hash') }}" # mypassword
         harden_linux_ntp: "ntp"
         harden_linux_ntp_settings:
@@ -127,6 +134,13 @@ provisioner:
         harden_linux_absent_packages:
           - dosfstools
       test-harden-linux-ubuntu2204-openntpd:
+        harden_linux_deploy_group: "deployer"
+        harden_linux_deploy_group_gid: "9999"
+        harden_linux_deploy_user: "deployer"
+        harden_linux_deploy_user_uid: "9998"
+        harden_linux_deploy_user_password: "{{ lookup('file', 'myuserpassword_hash') }}" # mypassword
+        harden_linux_deploy_user_home: "/home/deployer"
+        harden_linux_deploy_user_shell: "/bin/bash"
         harden_linux_ntp: "openntpd"
         harden_linux_ntp_settings:
           "^servers 0": "servers 0.debian.pool.ntp.org"
@@ -134,6 +148,15 @@ provisioner:
           "^servers 2": "servers 2.debian.pool.ntp.org"
           "^servers 3": "servers 3.debian.pool.ntp.org"
       test-harden-linux-arch-timesyncd:
+        harden_linux_deploy_group: "deployer"
+        harden_linux_deploy_group_gid: "9999"
+        harden_linux_deploy_user: "deployer"
+        harden_linux_deploy_user_uid: "9998"
+        harden_linux_deploy_user_password: "{{ lookup('file', 'myuserpassword_hash') }}" # mypassword
+        harden_linux_deploy_user_home: "/home/deployer"
+        harden_linux_deploy_user_shell: "/bin/bash"
+        harden_linux_deploy_user_public_keys:
+          - "mykey.pub"
         harden_linux_root_password: "{{ lookup('file', 'myuserpassword_hash') }}" # mypassword
         harden_linux_ntp: "systemd-timesyncd"
         harden_linux_optional_packages:

--- a/tasks/deployuser.yml
+++ b/tasks/deployuser.yml
@@ -4,24 +4,34 @@
     pkg: "sudo"
     state: present
 
+- name: Add deploy user's group
+  when:
+    - harden_linux_deploy_group != "root"
+  ansible.builtin.group:
+    name: "{{ harden_linux_deploy_group }}"
+    state: present
+    gid: "{{ harden_linux_deploy_group_gid | default(omit) }}"
+
 - name: Add deploy user
+  when:
+    - harden_linux_deploy_user != "root"
   ansible.builtin.user:
     name: "{{ harden_linux_deploy_user }}"
-    password: "{{ harden_linux_deploy_user_password }}"
-    uid: "{{ harden_linux_deploy_user_uid }}"
-    shell: "{{ harden_linux_deploy_user_shell }}"
-    home: "{{ harden_linux_deploy_user_home }}"
-  tags:
-    - user
+    state: present
+    shell: "{{ harden_linux_deploy_user_shell | default(omit) }}"
+    create_home: "{{ harden_linux_deploy_user_home is defined }}"
+    home: "{{ harden_linux_deploy_user_home | default(omit) }}"
+    uid: "{{ harden_linux_deploy_user_uid | default(omit) }}"
+    group: "{{ harden_linux_deploy_group }}"
+    password: "{{ harden_linux_deploy_user_password | default(omit) }}"
 
 - name: Add authorized keys for deploy user
+  when:
+    - harden_linux_deploy_user_public_keys is defined
   ansible.posix.authorized_key:
     user: "{{ harden_linux_deploy_user }}"
     key: "{{ lookup('file', item) }}"
   loop: "{{ harden_linux_deploy_user_public_keys }}"
-  when: harden_linux_deploy_user_public_keys is defined
-  tags:
-    - user
 
 - name: "Ensure deploy user present in /etc/sudoers.d/{{ harden_linux_deploy_user }}"
   ansible.builtin.template:
@@ -30,15 +40,9 @@
     owner: "root"
     group: "root"
     mode: "0400"
-  tags:
-    - user
-    - sudo
 
 - name: Ensure deploy user is absent in /etc/sudoers
   ansible.builtin.lineinfile:
     dest: "/etc/sudoers"
     regexp: "^{{ harden_linux_deploy_user }} ALL"
     state: absent
-  tags:
-    - user
-    - sudo

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -65,6 +65,9 @@
     - ntpd
 
 - name: Setup deploy user
+  when:
+    - harden_linux_deploy_group is defined
+    - harden_linux_deploy_user is defined
   ansible.builtin.include_tasks:
     file: "deployuser.yml"
     apply:


### PR DESCRIPTION
BREAKING/FEATURE

- introduce `harden_linux_deploy_group` and `harden_linux_deploy_group_gid` variables. Both are optional. But at least `harden_linux_deploy_group` must be specified if `harden_linux_deploy_user` is also set. If `harden_linux_deploy_group` is set to `root` nothing will be changed.
- if `harden_linux_deploy_user` is set to `root` nothing will be changed.
- `harden_linux_deploy_user` is now optional. If not set, no user will be setup. Also all variables that start with `harden_linux_deploy_user_` are only used if `harden_linux_deploy_user` is specified. Additionally `harden_linux_deploy_user_home` variable was added. `harden_linux_deploy_user_shell`, `harden_linux_deploy_user_home`, `harden_linux_deploy_user_uid` and `harden_linux_deploy_user_password` are now optional. $HOME directory of `harden_linux_deploy_user` is only created if `harden_linux_deploy_user_home` is set.

MOLECULE

- update test scenario to reflect deploy user/group changes