### PR TITLE
V8.1.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,5 +35,4 @@ jobs:
 
       - name: Trigger a new import on Galaxy.
         run: >-
-          ansible-galaxy role import --api-key ${{ secrets.GALAXY_API_KEY }}
-          $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)
+          ansible-galaxy role import --token ${{ secrets.GALAXY_API_KEY }} -vvvvvvvv --role-name=$(echo ${{ github.repository }} | cut -d/ -f2 | sed 's/ansible-role-//' | sed 's/-/_/') $(echo ${{ github.repository }} | cut -d/ -f1) $(echo ${{ github.repository }} | cut -d/ -f2)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - **OTHER**
   - update comments about using `mkpasswd` instead of `ansible` to create encrypted password
   - Ubuntu: add autoremove task
+  - update Github workflow
 
 - **MOLECULE**
   - use `alvistack` instead of `generic` Vagrant boxes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,54 +1,52 @@
 # Changelog
 
+## v8.1.0
+
+- **OTHER**
+  - update comments about using `mkpasswd` instead of `ansible` to create encrypted password
+  - Ubuntu: add autoremove task
+
 ## v8.0.0
 
-BREAKING/FEATURE
+- **BREAKING/FEATURE**
+  - introduce `harden_linux_deploy_group` and `harden_linux_deploy_group_gid` variables. Both are optional. But at least `harden_linux_deploy_group` must be specified if `harden_linux_deploy_user` is also set. If `harden_linux_deploy_group` is set to `root` nothing will be changed.
+  - if `harden_linux_deploy_user` is set to `root` nothing will be changed.
+  - `harden_linux_deploy_user` is now optional. If not set, no user will be setup. Also all variables that start with `harden_linux_deploy_user_` are only used if `harden_linux_deploy_user` is specified. Additionally `harden_linux_deploy_user_home` variable was added. `harden_linux_deploy_user_shell`, `harden_linux_deploy_user_home`, `harden_linux_deploy_user_uid` and `harden_linux_deploy_user_password` are now optional. $HOME directory of `harden_linux_deploy_user` is only created if `harden_linux_deploy_user_home` is set.
 
-- introduce `harden_linux_deploy_group` and `harden_linux_deploy_group_gid` variables. Both are optional. But at least `harden_linux_deploy_group` must be specified if `harden_linux_deploy_user` is also set. If `harden_linux_deploy_group` is set to `root` nothing will be changed.
-- if `harden_linux_deploy_user` is set to `root` nothing will be changed.
-- `harden_linux_deploy_user` is now optional. If not set, no user will be setup. Also all variables that start with `harden_linux_deploy_user_` are only used if `harden_linux_deploy_user` is specified. Additionally `harden_linux_deploy_user_home` variable was added. `harden_linux_deploy_user_shell`, `harden_linux_deploy_user_home`, `harden_linux_deploy_user_uid` and `harden_linux_deploy_user_password` are now optional. $HOME directory of `harden_linux_deploy_user` is only created if `harden_linux_deploy_user_home` is set.
-
-MOLECULE
-
-- update test scenario to reflect deploy user/group changes
+- **MOLECULE**
+  - update test scenario to reflect deploy user/group changes
 
 ## v7.1.0
 
-FEATURE
+- **FEATURE**
+  - introduce `harden_linux_absent_packages` variable
+  - introduce `harden_linux_systemd_resolved_settings` variable
 
-- introduce `harden_linux_absent_packages` variable
-- introduce `harden_linux_systemd_resolved_settings` variable
+- **MOLECULE**
+  - change IP addresses
 
-MOLECULE
-
-- change IP addresses
-
-OTHER
-
-- fix `ansible-lint` issues
+- **OTHER**
+  - fix `ansible-lint` issues
 
 ## v7.0.0
 
-BREAKING
-
-- `meta/main.yml`: change `role_name` from `harden-linux` to `harden_linux`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
+- **BREAKING**
+  - `meta/main.yml`: change `role_name` from `harden-linux` to `harden_linux`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
 - remove support for Ubuntu 18.04 (reached EOL)
 
-MOLECULE
+- **MOLECULE**
+  - add `verify` step
+  - use `generic/ubuntu2204` VM image instead of `alvistack/ubuntu-22.04`
+  - move `memory` and `cpus` properties to hosts
+  - rename scenario `kvm` to `default`
+  - rename `test-harden-linux-ubuntu1804-openntpd` to `test-harden-linux-ubuntu2204-openntpd`
+  - adjust `verifier`
+  - fix link in `defaults/main.yml`
+  - add information about Molecule test to `README.md`
 
-- add `verify` step
-- use `generic/ubuntu2204` VM image instead of `alvistack/ubuntu-22.04`
-- move `memory` and `cpus` properties to hosts
-- rename scenario `kvm` to `default`
-- rename `test-harden-linux-ubuntu1804-openntpd` to `test-harden-linux-ubuntu2204-openntpd`
-- adjust `verifier`
-- fix link in `defaults/main.yml`
-- add information about Molecule test to `README.md`
-
-OTHER
-
-- fix various `ansible-lint` issues
-- `.ansible-lint`: remove `role-name` / add `name[template]`
+- **OTHER**
+  - fix various `ansible-lint` issues
+  - `.ansible-lint`: remove `role-name` / add `name[template]`
 
 ## v6.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - **MOLECULE**
   - use `alvistack` instead of `generic` Vagrant boxes
+  - use different IP addresses
 
 ## v8.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   - update comments about using `mkpasswd` instead of `ansible` to create encrypted password
   - Ubuntu: add autoremove task
 
+- **MOLECULE**
+  - use `alvistack` instead of `generic` Vagrant boxes
+
 ## v8.0.0
 
 - **BREAKING/FEATURE**

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ See full  [CHANGELOG.md](https://github.com/githubixx/ansible-role-harden-linux/
 - **OTHER**
   - update comments about using `mkpasswd` instead of `ansible` to create encrypted password
   - Ubuntu: add autoremove task
+  - update Github workflow
 
 - **MOLECULE**
   - use `alvistack` instead of `generic` Vagrant boxes

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ See full  [CHANGELOG.md](https://github.com/githubixx/ansible-role-harden-linux/
 
 - **MOLECULE**
   - use `alvistack` instead of `generic` Vagrant boxes
+  - use different IP addresses
 
 ### v8.0.0
 

--- a/README.md
+++ b/README.md
@@ -44,18 +44,6 @@ See full  [CHANGELOG.md](https://github.com/githubixx/ansible-role-harden-linux/
 - **MOLECULE**
   - update test scenario to reflect deploy user/group changes
 
-### v7.1.0
-
-- **FEATURE**
-  - introduce `harden_linux_absent_packages` variable
-  - introduce `harden_linux_systemd_resolved_settings` variable
-
-- **MOLECULE**
-  - change IP addresses
-
-- **OTHER**
-  - fix `ansible-lint` issues
-
 ## Installation
 
 - Directly download from Github (Change into Ansible role directory before cloning. You can figure out the role path by using `ansible-config dump | grep DEFAULT_ROLES_PATH` command):

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ See full  [CHANGELOG.md](https://github.com/githubixx/ansible-role-harden-linux/
   - update comments about using `mkpasswd` instead of `ansible` to create encrypted password
   - Ubuntu: add autoremove task
 
+- **MOLECULE**
+  - use `alvistack` instead of `generic` Vagrant boxes
+
 ### v8.0.0
 
 - **BREAKING/FEATURE**

--- a/README.md
+++ b/README.md
@@ -24,55 +24,33 @@ See full  [CHANGELOG.md](https://github.com/githubixx/ansible-role-harden-linux/
 
 **Recent changes:**
 
+### v8.1.0
+
+- **OTHER**
+  - update comments about using `mkpasswd` instead of `ansible` to create encrypted password
+  - Ubuntu: add autoremove task
+
 ### v8.0.0
 
-BREAKING/FEATURE
+- **BREAKING/FEATURE**
+  - introduce `harden_linux_deploy_group` and `harden_linux_deploy_group_gid` variables. Both are optional. But at least `harden_linux_deploy_group` must be specified if `harden_linux_deploy_user` is also set. If `harden_linux_deploy_group` is set to `root` nothing will be changed.
+  - if `harden_linux_deploy_user` is set to `root` nothing will be changed.
+  - `harden_linux_deploy_user` is now optional. If not set, no user will be setup. Also all variables that start with `harden_linux_deploy_user_` are only used if `harden_linux_deploy_user` is specified. Additionally `harden_linux_deploy_user_home` variable was added. `harden_linux_deploy_user_shell`, `harden_linux_deploy_user_home`, `harden_linux_deploy_user_uid` and `harden_linux_deploy_user_password` are now optional. $HOME directory of `harden_linux_deploy_user` is only created if `harden_linux_deploy_user_home` is set.
 
-- introduce `harden_linux_deploy_group` and `harden_linux_deploy_group_gid` variables. Both are optional. But at least `harden_linux_deploy_group` must be specified if `harden_linux_deploy_user` is also set. If `harden_linux_deploy_group` is set to `root` nothing will be changed.
-- if `harden_linux_deploy_user` is set to `root` nothing will be changed.
-- `harden_linux_deploy_user` is now optional. If not set, no user will be setup. Also all variables that start with `harden_linux_deploy_user_` are only used if `harden_linux_deploy_user` is specified. Additionally `harden_linux_deploy_user_home` variable was added. `harden_linux_deploy_user_shell`, `harden_linux_deploy_user_home`, `harden_linux_deploy_user_uid` and `harden_linux_deploy_user_password` are now optional. $HOME directory of `harden_linux_deploy_user` is only created if `harden_linux_deploy_user_home` is set.
-
-MOLECULE
-
-- update test scenario to reflect deploy user/group changes
+- **MOLECULE**
+  - update test scenario to reflect deploy user/group changes
 
 ### v7.1.0
 
-FEATURE
+- **FEATURE**
+  - introduce `harden_linux_absent_packages` variable
+  - introduce `harden_linux_systemd_resolved_settings` variable
 
-- introduce `harden_linux_absent_packages` variable
-- introduce `harden_linux_systemd_resolved_settings` variable
+- **MOLECULE**
+  - change IP addresses
 
-MOLECULE
-
-- change IP addresses
-
-OTHER
-
-- fix `ansible-lint` issues
-
-### v7.0.0
-
-BREAKING
-
-- `meta/main.yml`: change `role_name` from `harden-linux` to `harden_linux`. This is a requirement since quite some time for Ansible Galaxy. But the requirement was introduced after this role already existed for quite some time. So please update the name of the role in your playbook accordingly!
-- remove support for `Ubuntu 18.04` (reached EOL)
-
-MOLECULE
-
-- add `verify` step
-- use `generic/ubuntu2204` VM image instead of `alvistack/ubuntu-22.04`
-- move `memory` and `cpus` properties to hosts
-- rename scenario `kvm` to `default`
-- rename `test-harden-linux-ubuntu1804-openntpd` to `test-harden-linux-ubuntu2204-openntpd`
-- adjust `verifier`
-- fix link in `defaults/main.yml`
-- add information about Molecule test to `README.md`
-
-OTHER
-
-- fix various `ansible-lint` issues
-- `.ansible-lint`: remove `role-name` / add `name[template]`
+- **OTHER**
+  - fix `ansible-lint` issues
 
 ## Installation
 
@@ -90,17 +68,17 @@ OTHER
 roles:
   - name: githubixx.harden_linux
     src: https://github.com/githubixx/ansible-role-harden-linux.git
-    version: v7.1.0
+    version: v8.1.0
 ```
 
 ## Role Variables
 
 The following variables don't have defaults. You need to specify them either in a file in `group_vars` or `host_vars` directory. E.g. if this settings should be used only for one specific host create a file for that host called like the FQDN of that host (e.g `host_vars/your-server.example.tld`) and put the variables with the correct values there. If you want to apply this variables to a host group create a file `group_vars/your-group.yml` e.g. Replace `your-group` with the host group name which you created in the Ansible `hosts` file (do not confuse with /etc/hosts...).
 
-If you want to set or change the password of the `root` user set `harden_linux_root_password` variable. This is optional. It expects an encrypted password. Ansible won't encrypt the password for you. How to create an encrypted password is described in the [Ansible FAQs](http://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module). But as Ansible is installed anyways the easiest way is most probably the following command:
+If you want to set or change the password of the `root` user set `harden_linux_root_password` variable. This is optional. It expects an encrypted password. Ansible won't encrypt the password for you. How to create an encrypted password is described in the [Ansible FAQs](http://docs.ansible.com/ansible/latest/reference_appendices/faq.html#how-do-i-generate-encrypted-passwords-for-the-user-module). On Linux the following command is most probably the most reliable one:
 
 ```bash
-ansible localhost -m debug -a "msg={{ 'mypassword' | password_hash('sha512', 'mysecretsalt') }}"
+mkpasswd --method=sha-512
 ```
 
 To install a user that can execute commands with `sudo` without password set the following variables:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,7 +2,7 @@
 # If you want to set or change the password of the "root" user set this variable.
 #
 # The encrypted password can be created with the following command:
-# ansible localhost -m debug -a "msg={{ 'mypassword' | password_hash('sha512', 'mysecretsalt') }}"
+# mkpasswd --method=sha-512
 #
 # harden_linux_root_password: "a_password"
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -10,7 +10,7 @@ driver:
 
 platforms:
   - name: test-harden-linux-ubuntu2004-timesyncd
-    box: generic/ubuntu2004
+    box: alvistack/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -21,7 +21,7 @@ platforms:
         type: static
         ip: 10.66.66.10
   - name: test-harden-linux-ubuntu2004-ntp
-    box: generic/ubuntu2004
+    box: alvistack/ubuntu-20.04
     memory: 2048
     cpus: 2
     groups:
@@ -32,7 +32,7 @@ platforms:
         type: static
         ip: 10.66.66.20
   - name: test-harden-linux-ubuntu2204-openntpd
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:
@@ -54,7 +54,7 @@ platforms:
         type: static
         ip: 10.66.66.40
   - name: test-harden-linux-ubuntu2204-timesyncd
-    box: generic/ubuntu2204
+    box: alvistack/ubuntu-22.04
     memory: 2048
     cpus: 2
     groups:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,7 +19,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 10.66.66.10
+        ip: 172.16.10.10
   - name: test-harden-linux-ubuntu2004-ntp
     box: alvistack/ubuntu-20.04
     memory: 2048
@@ -30,7 +30,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 10.66.66.20
+        ip: 172.16.10.20
   - name: test-harden-linux-ubuntu2204-openntpd
     box: alvistack/ubuntu-22.04
     memory: 2048
@@ -41,7 +41,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 10.66.66.30
+        ip: 172.16.10.30
   - name: test-harden-linux-arch-timesyncd
     box: archlinux/archlinux
     memory: 2048
@@ -52,7 +52,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 10.66.66.40
+        ip: 172.16.10.40
   - name: test-harden-linux-ubuntu2204-timesyncd
     box: alvistack/ubuntu-22.04
     memory: 2048
@@ -63,7 +63,7 @@ platforms:
       - auto_config: true
         network_name: private_network
         type: static
-        ip: 10.66.66.50
+        ip: 172.16.10.50
 
 provisioner:
   name: ansible

--- a/molecule/default/myuserpassword_hash
+++ b/molecule/default/myuserpassword_hash
@@ -1,1 +1,1 @@
-$6$mysecretsalt$qJbapG68nyRab3gxvKWPUcs2g3t0oMHSHMnSKecYNpSi3CuZm.GbBqXO8BE6EI6P1JUefhA0qvD7b5LSh./PU1
+$6$n5cZx1LIxnnAFyPL$mEh4G/BzI.g1kqXFOVzTpmMS/xSJm6uIjH4i64dTegJ4gAs4te9FgBjAhaCZwxWjD14ideOA04/NfDzvlS/j//

--- a/tasks/setup-ubuntu.yml
+++ b/tasks/setup-ubuntu.yml
@@ -13,9 +13,18 @@
   tags:
     - apt
 
+- name: "({{ ansible_distribution }}) APT autoremove"
+  ansible.builtin.apt:
+    autoremove: true
+  retries: 2
+  delay: 5
+  tags:
+    - apt
+
 - name: "({{ ansible_distribution }}) Upgrade APT to the latest packages"
   ansible.builtin.apt:
     upgrade: safe
+    autoremove: true
   retries: 2
   delay: 5
   tags:


### PR DESCRIPTION
- **OTHER**
  - update comments about using `mkpasswd` instead of `ansible` to create encrypted password
  - Ubuntu: add autoremove task
  - update Github workflow

- **MOLECULE**
  - use `alvistack` instead of `generic` Vagrant boxes
  - use different IP addresses